### PR TITLE
Add websocket for now playing

### DIFF
--- a/scripts/song-ws-server.cjs
+++ b/scripts/song-ws-server.cjs
@@ -1,0 +1,44 @@
+const http = require('node:http');
+const { writeFile } = require('node:fs/promises');
+const nodeAdapter = require('crossws/adapters/node').default;
+let lastTrack = null;
+const path = require('node:path');
+const dataFilePath = path.resolve(__dirname, '../data/latest-song.json');
+async function getNowPlaying() {
+	const mod = await import('../src/lib/lastfm.js');
+	return mod.getLastFmNowPlaying();
+}
+const wss = nodeAdapter({
+	hooks: {
+		open(peer) {
+			if (lastTrack) {
+				peer.send(JSON.stringify(lastTrack));
+			}
+		},
+	},
+});
+const server = http.createServer();
+server.on('upgrade', (req, socket, head) => {
+	wss.handleUpgrade(req, socket, head);
+});
+async function checkSong() {
+	try {
+		const track = await getNowPlaying();
+		if (track && JSON.stringify(track) !== JSON.stringify(lastTrack)) {
+			lastTrack = track;
+			const data = JSON.stringify(track);
+			await writeFile(dataFilePath, data, 'utf-8');
+			for (const peer of wss.peers) {
+				peer.send(data);
+			}
+		}
+	} catch (err) {
+		console.error('Failed to fetch song:', err);
+	}
+}
+setInterval(checkSong, 15000);
+checkSong();
+const PORT = process.env.SONG_WS_PORT || 3001;
+server.listen(PORT, () => {
+	console.log(`WebSocket server listening on ws://localhost:${PORT}`);
+});

--- a/src/lib/lastfm.js
+++ b/src/lib/lastfm.js
@@ -1,0 +1,21 @@
+export const LASTFM_API_KEY = 'ed1bfb5cb9c759f5a032ed7233ea462e';
+export const LASTFM_USERNAME = 'AbdallahAHO';
+
+export async function getLastFmNowPlaying() {
+	const response = await fetch(
+		`https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${LASTFM_USERNAME}&api_key=${LASTFM_API_KEY}&format=json&limit=1`
+	);
+	const data = await response.json();
+	const track = data.recenttracks?.track?.[0];
+
+	if (!track) return null;
+
+	return {
+		name: track.name,
+		artist: track.artist['#text'],
+		album: track.album['#text'],
+		art: track.image[2]['#text'],
+		url: track.url,
+		isPlaying: track['@attr']?.nowplaying === 'true',
+	};
+}

--- a/src/pages/api/latest-song.js
+++ b/src/pages/api/latest-song.js
@@ -1,28 +1,7 @@
 import { writeFile } from 'node:fs/promises';
-
-const LASTFM_API_KEY = 'ed1bfb5cb9c759f5a032ed7233ea462e';
-const LASTFM_USERNAME = 'AbdallahAHO';
+import { getLastFmNowPlaying } from '../../lib/lastfm.js';
 
 const dataFilePath = new URL('../../../data/latest-song.json', import.meta.url);
-
-async function getLastFmNowPlaying() {
-	const response = await fetch(
-		`https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${LASTFM_USERNAME}&api_key=${LASTFM_API_KEY}&format=json&limit=1`
-	);
-	const data = await response.json();
-	const track = data.recenttracks?.track?.[0];
-
-	if (!track) return null;
-
-	return {
-		name: track.name,
-		artist: track.artist['#text'],
-		album: track.album['#text'],
-		art: track.image[2]['#text'],
-		url: track.url,
-		isPlaying: track['@attr']?.nowplaying === 'true',
-	};
-}
 
 export const GET = async () => {
 	try {


### PR DESCRIPTION
## Summary
- share Last.fm helper to get currently playing track
- use new helper in latest-song API
- show updates via WebSocket on /now page
- provide server script that pushes track changes and stores the latest JSON

## Testing
- `npx biome format scripts/song-ws-server.cjs src/lib/lastfm.js src/pages/api/latest-song.js src/components/CurrentlyPlaying.jsx --write`
- `npx biome lint scripts/song-ws-server.cjs src/lib/lastfm.js src/pages/api/latest-song.js src/components/CurrentlyPlaying.jsx`
- `pnpm lint`
- `node -e "require('./scripts/song-ws-server.cjs');"` *(fails: getaddrinfo ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_b_6839cf9201e083259720e6cd42ea62c8